### PR TITLE
Fix font-size for devtools

### DIFF
--- a/userChrome/chrome/theme/dracula.css
+++ b/userChrome/chrome/theme/dracula.css
@@ -239,10 +239,10 @@ body[lwt-sidebar-brighttext][style*="--lwt-sidebar-background-color: rgb(56, 56,
         line-height: 1.3 !important;
         font-weight: normal !important;
     }
-}
 
-div, [platform="linux"]:root .devtools-monospace{
-    font-size: 13px !important;
+    div, [platform="linux"]:root .devtools-monospace{
+        font-size: 13px !important;
+    }
 }
 
 @-moz-document url-prefix("about:newtab"),


### PR DESCRIPTION
Move rule into the proper @-moz-document rule so that it only applies to the devtools. The loose `div` with a `font-size: 13px !important` breaks several websites. For example, text selection is nearly impossible on GitHub and the font size is way too small on Wikipedia.